### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install:
 
 .. code-block:: bash
 
-    pip install agatesql
+    pip install agate-sql
 
 For details on development or supported platforms see the `agate documentation <http://agate.readthedocs.org>`_.
 


### PR DESCRIPTION
```pip search agate``` shows the package to install is ```agate-sql``` but it imports as ```agatesql```. Fix in docs to remedy this.

<img width="1344" alt="screen shot 2016-04-20 at 4 48 35 pm" src="https://cloud.githubusercontent.com/assets/433780/14693871/d3943c32-0717-11e6-9a88-b238e0d09140.png">
