### PR TITLE
pip install agate-sql

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install:
 
 .. code-block:: bash
 
-    pip install agatesql
+    pip install agate-sql
 
 For details on development or supported platforms see the `agate documentation <http://agate.readthedocs.org>`_.
 


### PR DESCRIPTION
```sh
$ pip install agatesql
Collecting agatesql
  Could not find a version that satisfies the requirement agatesql (from versions: )
No matching distribution found for agatesql
```
So...
```sh
$ pip install agate-sql
Collecting agate-sql
  Using cached agate_sql-0.3.0-py2.py3-none-any.whl
Collecting sqlalchemy>=1.0.8 (from agate-sql)
Requirement already satisfied (use --upgrade to upgrade): agate>=1.1.0 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate-sql)
Requirement already satisfied (use --upgrade to upgrade): pytimeparse>=1.1.5 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate>=1.1.0->agate-sql)
Requirement already satisfied (use --upgrade to upgrade): Babel>=2.0 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate>=1.1.0->agate-sql)
Requirement already satisfied (use --upgrade to upgrade): isodate>=0.5.4 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate>=1.1.0->agate-sql)
Requirement already satisfied (use --upgrade to upgrade): parsedatetime>=2.1 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate>=1.1.0->agate-sql)
Requirement already satisfied (use --upgrade to upgrade): six>=1.6.1 in ./.virtualenvs/test_this/lib/python2.7/site-packages (from agate>=1.1.0->agate-sql)
Requirement already satisfied (use --upgrade to upgrade): pytz>=0a in ./.virtualenvs/test_this/lib/python2.7/site-packages (from Babel>=2.0->agate>=1.1.0->agate-sql)
Installing collected packages: sqlalchemy, agate-sql
Successfully installed agate-sql-0.3.0 sqlalchemy-1.0.12
```
