### PR TITLE
Add prefixes option to .to_sql

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
 0.5.1
 -----
 
-
+* Add ``prefixes`` option to :func:`.to_sql`.
 
 0.5.0 - December 23, 2016
 -------------------------
 
 * ``VARCHAR`` columns are now generated with proper length constraints (unless explicilty disabled).
-* Tables can now be created from query results using :func:`.from_sql_query`
+* Tables can now be created from query results using :func:`.from_sql_query`.
 * Add support for running queries directly on tables with :func:`.sql_query`.
 * When creating tables, ``NOT NULL`` constraints will be created by default.
 * SQL create statements can now be generated without being executed with :func:`.to_sql_create_statement`

--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -173,7 +173,7 @@ def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=
 
     return sql_table
 
-def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, insert=True, db_schema=None, constraints=True):
+def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, insert=True, prefixes=[], db_schema=None, constraints=True):
     """
     Write this table to the given SQL database.
 
@@ -189,6 +189,8 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
         Create the table.
     :param insert:
         Insert table data.
+    :param prefixes:
+        Add prefixes to the insert query.
     :param db_schema:
         Create table in the specified database schema.
     :param constraints
@@ -207,6 +209,8 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
 
     if insert:
         insert = sql_table.insert()
+        for prefix in prefixes:
+            insert.prefix_with(prefix)
         connection.execute(insert, [dict(zip(self.column_names, row)) for row in self.rows])
 
     return sql_table


### PR DESCRIPTION
Needed to add a --prefixes option to csvkit's csvsql for https://github.com/wireservice/csvkit/issues/200