### PR TITLE
Add create_ifne flag to to_sql method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ The following individuals have contributed code to agate-sql:
 * `Chris Keller <https://github.com/chrislkeller>`_
 * `git-clueless <https://github.com/git-clueless>`_
 * `z2s8 <https://github.com/z2s8>`_
+* `Jake Zimmerman <https://github.com/jez>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 0.5.2
 -----
 
-* Add ``create_ifne`` flag to :meth:`.TableSQL.to_sql`.
+* Add ``create_if_not_exists`` flag to :meth:`.TableSQL.to_sql`.
 
 0.5.1 -  February 27, 2017
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 0.5.2
 -----
 
-
+* Add ``create_ifne`` flag to :meth:`.TableSQL.to_sql`.
 
 0.5.1 -  February 27, 2017
 --------------------------

--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -176,7 +176,7 @@ def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=
 
     return sql_table
 
-def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, create_ifne=False, insert=True, prefixes=[], db_schema=None, constraints=True):
+def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, create_if_not_exists=False, insert=True, prefixes=[], db_schema=None, constraints=True):
     """
     Write this table to the given SQL database.
 
@@ -190,7 +190,7 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
         Drop any existing table with the same name before creating.
     :param create:
         Create the table.
-    :param create_ifne:
+    :param create_if_not_exists:
         When creating the table, don't fail if the table already exists.
     :param insert:
         Insert table data.
@@ -210,7 +210,7 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
         if overwrite:
             sql_table.drop(checkfirst=True)
 
-        sql_table.create(checkfirst=create_ifne)
+        sql_table.create(checkfirst=create_if_not_exists)
 
     if insert:
         insert = sql_table.insert()

--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -176,7 +176,7 @@ def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=
 
     return sql_table
 
-def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, insert=True, prefixes=[], db_schema=None, constraints=True):
+def to_sql(self, connection_or_string, table_name, overwrite=False, create=True, create_ifne=False, insert=True, prefixes=[], db_schema=None, constraints=True):
     """
     Write this table to the given SQL database.
 
@@ -190,6 +190,8 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
         Drop any existing table with the same name before creating.
     :param create:
         Create the table.
+    :param create_ifne:
+        When creating the table, don't fail if the table already exists.
     :param insert:
         Insert table data.
     :param prefixes:
@@ -208,7 +210,7 @@ def to_sql(self, connection_or_string, table_name, overwrite=False, create=True,
         if overwrite:
             sql_table.drop(checkfirst=True)
 
-        sql_table.create()
+        sql_table.create(checkfirst=create_ifne)
 
     if insert:
         insert = sql_table.insert()

--- a/tests/test_agatesql.py
+++ b/tests/test_agatesql.py
@@ -54,6 +54,28 @@ class TestSQL(agate.AgateTestCase):
         self.assertEqual(len(table.rows), len(self.table.rows))
         self.assertSequenceEqual(table.rows[0], self.table.rows[0])
 
+    def test_create_if_not_exists(self):
+        column_names = ['id', 'name']
+        column_types = [agate.Number(), agate.Text()]
+        rows1 = (
+            (1, 'Jake'),
+            (2, 'Howard'),
+        )
+        rows2 = (
+            (3, 'Liz'),
+            (4, 'Tim'),
+        )
+
+        table1 = agate.Table(rows1, column_names, column_types)
+        table2 = agate.Table(rows2, column_names, column_types)
+
+        engine = create_engine(self.connection_string)
+        connection = engine.connect()
+
+        # Write two agate tables into the same SQL table
+        table1.to_sql(connection, 'create_if_not_exists_test', create=True, create_if_not_exists=True, insert=True)
+        table2.to_sql(connection, 'create_if_not_exists_test', create=True, create_if_not_exists=True, insert=True)
+
     def test_to_sql_create_statement(self):
         statement = self.table.to_sql_create_statement('test_table')
 


### PR DESCRIPTION
/cc @jpmckinney

Adds a `create_ifne` option to the `to_sql` method. This works by just using
SQLAlchemy's `checkfirst=` property.

This change is required downstream by csvkit to implement the behavior
described in wireservice/csvkit#813.