### PR TITLE
Ensure closing connection and disposing SQLAlchemy engine if required

### DIFF
--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -228,6 +228,8 @@ def to_sql(self, connection_or_string, table_name, overwrite=False,
         Create table in the specified database schema.
     :param constraints
         Generate constraints such as ``nullable`` for table columns.
+    :param chunksize
+        If not None, then rows will be written in batches of this size at a time. If None, all rows will be written at once.
     """
     engine, connection = get_connection(connection_or_string)
 

--- a/tests/test_agatesql.py
+++ b/tests/test_agatesql.py
@@ -168,7 +168,7 @@ class TestSQL(agate.AgateTestCase):
             for chunksize in [11, 100, 9, 231]:
                 # insert data with chunksize
                 table = agate.Table(rows, column_names, column_types)
-                table.to_sql(connection, 'test_chunksize', overwrite=True, chunksize=11)
+                table.to_sql(connection, 'test_chunksize', overwrite=True, chunksize=chunksize)
 
                 table = agate.Table.from_sql(connection, 'test_chunksize')
                 total = 0

--- a/tests/test_agatesql.py
+++ b/tests/test_agatesql.py
@@ -149,3 +149,34 @@ class TestSQL(agate.AgateTestCase):
         self.assertColumnNames(results, ['total'])
         self.assertColumnTypes(results, [agate.Number])
         self.assertRows(results, [[Decimal('3.123')]])
+
+    def test_chunksize(self):
+        column_names = ['number']
+        column_types = [agate.Number()]
+
+        n = 9999
+        rows = []
+        ref_total = 0
+        for k in range(n):
+            rows.append((k,))
+            ref_total += k
+
+        engine = create_engine(self.connection_string)
+        connection = engine.connect()
+
+        try:
+            for chunksize in [11, 100, 9, 231]:
+                # insert data with chunksize
+                table = agate.Table(rows, column_names, column_types)
+                table.to_sql(connection, 'test_chunksize', overwrite=True, chunksize=11)
+
+                table = agate.Table.from_sql(connection, 'test_chunksize')
+                total = 0
+                for r in table.rows:
+                    total += int(r[0])
+                self.assertEqual(len(table.rows), len(rows), "Number of rows")
+                self.assertEqual(ref_total, total, "Sum of all values")
+        finally:
+            connection.close()
+            engine.dispose()
+


### PR DESCRIPTION
Snowflake DB (https://www.snowflake.net/) is a cloud DB, which requires explicit closing connection and disposing the SQLAlchemy engine object for the clients to tell the server that the connection is no longer required or leaks sessions. Although the orphaned sessions will be purged eventually in the server side, it would be better for the clients to close them explicitly if no longer required.

This PR is an improvements in agatesql/table to ensure the connections are closed and the engine is destroyed if they are allocated within the methods.