### PR TITLE
Table.to_sql col_len_multiplier and min_col_len parameters added.

### DIFF
--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -161,7 +161,7 @@ def make_sql_column(column_name, column, sql_type_kwargs=None, sql_column_kwargs
 
 
 def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=True, unique_constraint=[],
-                   connection=None):
+                   connection=None, col_len_multiplier=1, min_col_len=1):
     """
     Generates a SQL alchemy table from an agate table.
     """
@@ -180,13 +180,13 @@ def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=
 
         if constraints:
             if isinstance(column.data_type, agate.Text) and dialect == 'mysql':
-                length = table.aggregate(agate.MaxLength(column_name))
+                length = table.aggregate(agate.MaxLength(column_name)) * decimal.Decimal(col_len_multiplier)
                 if length > 21844:
                     # @see https://dev.mysql.com/doc/refman/5.7/en/string-type-overview.html
                     sql_column_type = TEXT
                 else:
                     # If length is zero, SQLAlchemy may raise "VARCHAR requires a length on dialect mysql".
-                    sql_type_kwargs['length'] = length or 1
+                    sql_type_kwargs['length'] = length if length >= min_col_len else min_col_len
 
             # PostgreSQL and SQLite don't have scale default 0.
             # @see https://www.postgresql.org/docs/9.2/static/datatype-numeric.html
@@ -216,7 +216,8 @@ def make_sql_table(table, table_name, dialect=None, db_schema=None, constraints=
 
 def to_sql(self, connection_or_string, table_name, overwrite=False,
            create=True, create_if_not_exists=False, insert=True, prefixes=[],
-           db_schema=None, constraints=True, unique_constraint=[], chunk_size=None):
+           db_schema=None, constraints=True, unique_constraint=[], chunk_size=None, 
+           col_len_multiplier=1, min_col_len=1):
     """
     Write this table to the given SQL database.
 
@@ -244,12 +245,17 @@ def to_sql(self, connection_or_string, table_name, overwrite=False,
         The names of the columns to include in a UNIQUE constraint.
     :param chunk_size
         Write rows in batches of this size. If not set, rows will be written at once.
+    :param col_len_multiplier
+        Multiply max column width by this multiplier to accomodate larger values in later runs.
+    :param col_min_len
+        Minimum size for text columns.
     """
     engine, connection = get_engine_and_connection(connection_or_string)
 
     dialect = connection.engine.dialect.name
     sql_table = make_sql_table(self, table_name, dialect=dialect, db_schema=db_schema, constraints=constraints,
-                               unique_constraint=unique_constraint, connection=connection)
+                               unique_constraint=unique_constraint, connection=connection, 
+                               col_len_multiplier=col_len_multiplier, min_col_len=min_col_len)
 
     if create:
         if overwrite:

--- a/tests/test_agatesql.py
+++ b/tests/test_agatesql.py
@@ -8,7 +8,6 @@ import agatesql  # noqa
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 
-
 class TestSQL(agate.AgateTestCase):
     def setUp(self):
         self.rows = (
@@ -178,6 +177,30 @@ class TestSQL(agate.AgateTestCase):
   id DECIMAL(38, 0) NOT NULL, 
   name TEXT
 );''')  # noqa
+
+    def test_make_sql_table_col_len_multiplier(self):
+        rows = ((1, 'x' * 10), (2, ''))
+        column_names = ['id', 'name']
+        column_types = [agate.Number(), agate.Text()]
+        table = agate.Table(rows, column_names, column_types)
+
+        sql_table = agatesql.table.make_sql_table(table, 'test_table', dialect='mysql', db_schema='test_schema',
+                                                  constraints=True, col_len_multiplier=1.5)
+
+
+        self.assertEquals(sql_table.columns.get('name').type.length, 15)
+
+    def test_make_sql_table_min_col_len(self):
+        rows = ((1, 'x' * 10), (2, ''))
+        column_names = ['id', 'name']
+        column_types = [agate.Number(), agate.Text()]
+        table = agate.Table(rows, column_names, column_types)
+
+        sql_table = agatesql.table.make_sql_table(table, 'test_table', dialect='mysql', db_schema='test_schema', 
+                                                  constraints=True, min_col_len=20)
+
+
+        self.assertEquals(sql_table.columns.get('name').type.length, 20)
 
     def test_sql_query_simple(self):
         results = self.table.sql_query('select * from agate')


### PR DESCRIPTION
Two parameters have been added to Table.to_sql and Table.make_sql_table to allow for larger column widths than what is present in the sheet used to create the table.  This will allow for subsequent runs where field values may exceed the max from the initial sheet without truncating the value in the database.  The "col_len_multiplier" is multiplied against the max length when creating the table.  Default is 1 and this should not change current behavior.  The "min_col_len" can be used alone or in conjunction with the multiplier to ensure that, no matter what, VARCHAR columns will not be less than this value.  Default is 1 an leaves the zero-length checking behavior unchanged.

Tests were added for the new fields.  All existing tests pass unchanged.