### PR TITLE
Migrate to SQLAlchemy 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
         'agate>=1.5.0',
-        'sqlalchemy<2',
+        'sqlalchemy>=1.4',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Remove the upper bound on SQLAlchemy by converting the code idioms in use to support both SQLAlchemy 1.4 and SQLAlchemy 2, and only setting a lower bound SQLAlchemy of >= 1.4.

Closes #39