### PR TITLE
Use Connection.begin_nested() instead

### DIFF
--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -273,14 +273,15 @@ def to_sql(self, connection_or_string, table_name, overwrite=False,
                                min_col_len=min_col_len, col_len_multiplier=col_len_multiplier)
 
     if create:
-        with connection.begin():
+        with connection.begin_nested() as conn:
             if overwrite:
                 sql_table.drop(bind=connection, checkfirst=True)
 
             sql_table.create(bind=connection, checkfirst=create_if_not_exists)
+            conn.commit()
 
     if insert:
-        with connection.begin():
+        with connection.begin_nested() as conn:
             insert = sql_table.insert()
             for prefix in prefixes:
                 insert = insert.prefix_with(prefix)
@@ -294,6 +295,8 @@ def to_sql(self, connection_or_string, table_name, overwrite=False,
                         end_index = number_of_rows
                     connection.execute(insert, [dict(zip(self.column_names, row)) for row in
                                                 self.rows[index * chunk_size:end_index]])
+
+            conn.commit()
 
     try:
         return sql_table


### PR DESCRIPTION
Other libraries that consume this one may have their own transactions going on when we are called, so use begin_nested() to utilise savepointing instead, and don't forget to commit!